### PR TITLE
Players can jump unless they are holding a pickaxe

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -134,7 +134,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 4135639652
+  GlobalObjectIdHash: 1002304928
   InScenePlacedSourceGlobalObjectIdHash: 0
   AlwaysReplicateAsRoot: 0
   SynchronizeTransform: 1
@@ -165,7 +165,7 @@ MonoBehaviour:
   lowJumpMultiplier: 4
   coyoteTime: 0.083
   canJump:
-    m_InternalValue: 0
+    m_InternalValue: 1
   boxSize: {x: 0.5, y: 0.16}
   castDistance: 0.45
   groundLayer:

--- a/Assets/Scripts/Player/PlayerNetwork.cs
+++ b/Assets/Scripts/Player/PlayerNetwork.cs
@@ -25,7 +25,7 @@ public class PlayerNetwork : NetworkBehaviour
     [SerializeField] private float fallMultiplier = 2.5f;
     [SerializeField] private float lowJumpMultiplier = 2f;
     [SerializeField] private float coyoteTime = 0.1f;
-    public NetworkVariable<bool> canJump = new NetworkVariable<bool>(false, default, NetworkVariableWritePermission.Owner);
+    public NetworkVariable<bool> canJump = new NetworkVariable<bool>(true, default, NetworkVariableWritePermission.Owner);
 
     private float mayJumpTime;
     InputAction moveAction;
@@ -64,7 +64,7 @@ public class PlayerNetwork : NetworkBehaviour
     {
         inputActions = new PlayerInputActions();
         hasPickaxe.Value = false;
-        canJump.Value = false;
+        canJump.Value = true;
         NetworkManagerUI.OnMenuStateChange += OnMenuStateChange;
     }
 
@@ -216,7 +216,7 @@ public class PlayerNetwork : NetworkBehaviour
         if (mayJumpTime <= 0) return; // Check if we are still under coyote time, if not, we can't jump.
         if (insideDoorFrame) return; // El jugador no puede saltar cuando esta dentro de la zona de salida.
 
-        canJump.Value = false;
+        if(hasPickaxe.Value) canJump.Value = false; //If the player has the pickaxe and jumps after being granted a jump, they can't jump anymore.
         rb.velocity = Vector2.right * rb.velocity.x + Vector2.up * jumpForce;
 
     }
@@ -281,6 +281,7 @@ public class PlayerNetwork : NetworkBehaviour
         HandleReleasePickaxe();
 
         hasPickaxe.Value = false;
+        canJump.Value = true;
     }
 
     /// <summary>


### PR DESCRIPTION
Changes:
1. CanJump variable default value is true now, and therefore players can jump when the game has started.
2. When grabbing a pickaxe, however, they can't jump anymore.
3. If they release the pickaxe, players can jump again.